### PR TITLE
Add Middleware to verify Slack tokens.

### DIFF
--- a/config/laravel-slack.php
+++ b/config/laravel-slack.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Slack tokens
+    |--------------------------------------------------------------------------
+    |
+    | Register all your Slack slash command tokens in this array.
+    |
+    |
+    |
+    */
+
+    'slack_tokens' => [
+        '/yourCommand' => env('TOKEN_YOUR_COMMAND'),
+    ],
+
+];

--- a/src/Http/Middleware/VerifySlackToken.php
+++ b/src/Http/Middleware/VerifySlackToken.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Spatie\Skeleton\Http\Middleware;
+
+use Closure;
+use Exception;
+use Illuminate\Contracts\Config\Repository;
+
+class VerifySlackToken
+{
+    /**
+     * @var \Illuminate\Contracts\Config\Repository
+     */
+    private $config;
+
+    public function __construct(Repository $config)
+    {
+        $this->config = $config->get('laravel-slack.slack_tokens');
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param $request
+     * @param Closure $next
+     * @return mixed
+     * @throws Exception
+     */
+    public function handle($request, Closure $next)
+    {
+        if($this->config[$request->command] != $request->token) {
+            throw new Exception('Invalid Slack command token given');
+        }
+
+        return $next($request);
+    }
+}

--- a/src/SkeletonServiceProvider.php
+++ b/src/SkeletonServiceProvider.php
@@ -29,6 +29,17 @@ class SkeletonServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->mergeConfigFrom(__DIR__.'/../config/config.php', 'skeleton');
+        $this->mergeConfigFrom(__DIR__.'/../config/laravel-slack.php', 'laravel-slack');
+
+        $this->registerMiddleware();
     }
+
+    /**
+     * @return void
+     */
+    private function registerMiddleware()
+    {
+        $this->app['router']->middleware('VerifySlackToken', 'Spatie\Skeleton\Http\Middleware\VerifySlackToken');
+    }
+
 }


### PR DESCRIPTION
I created a config file where all tokens can be pulled from env files and merged the config file in the service provider.

I also created a method to register the middleware from in the service provider.

And last but not least a middleware class to verify the slack tokens.

This middleware is used to make sure that the calls to your application are coming from the correct Slack team and or command.

If you want me to add some additions or if something is not valid please let me know and I will update the code.

_Note: I used the skeleton namespace for the moment so make sure to change this one, once you have chosen the final package name._